### PR TITLE
feat: add guest role management

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1389,6 +1389,55 @@ USER_PERMISSIONS = PersistentConfig(
     DEFAULT_USER_PERMISSIONS,
 )
 
+DEFAULT_GUEST_PERMISSIONS = {
+    "workspace": {
+        "models": False,
+        "knowledge": False,
+        "prompts": False,
+        "tools": False,
+    },
+    "sharing": {
+        "public_models": False,
+        "public_knowledge": False,
+        "public_prompts": False,
+        "public_tools": False,
+    },
+    "chat": {
+        "controls": True,
+        "valves": True,
+        "system_prompt": True,
+        "params": True,
+        "file_upload": True,
+        "delete": True,
+        "delete_message": True,
+        "continue_response": True,
+        "regenerate_response": True,
+        "rate_response": True,
+        "edit": True,
+        "share": True,
+        "export": True,
+        "stt": True,
+        "tts": True,
+        "call": True,
+        "multiple_models": True,
+        "temporary": True,
+        "temporary_enforced": False,
+    },
+    "features": {
+        "direct_tool_servers": False,
+        "web_search": True,
+        "image_generation": True,
+        "code_interpreter": True,
+        "notes": True,
+    },
+}
+
+GUEST_PERMISSIONS = PersistentConfig(
+    "GUEST_PERMISSIONS",
+    "guest.permissions",
+    DEFAULT_GUEST_PERMISSIONS,
+)
+
 ENABLE_CHANNELS = PersistentConfig(
     "ENABLE_CHANNELS",
     "channels.enable",

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -336,6 +336,7 @@ from open_webui.config import (
     ENABLE_EVALUATION_ARENA_MODELS,
     BYPASS_ADMIN_ACCESS_CONTROL,
     USER_PERMISSIONS,
+    GUEST_PERMISSIONS,
     DEFAULT_USER_ROLE,
     PENDING_USER_OVERLAY_CONTENT,
     PENDING_USER_OVERLAY_TITLE,
@@ -717,6 +718,7 @@ app.state.config.PENDING_USER_OVERLAY_TITLE = PENDING_USER_OVERLAY_TITLE
 app.state.config.RESPONSE_WATERMARK = RESPONSE_WATERMARK
 
 app.state.config.USER_PERMISSIONS = USER_PERMISSIONS
+app.state.config.GUEST_PERMISSIONS = GUEST_PERMISSIONS
 app.state.config.WEBHOOK_URL = WEBHOOK_URL
 app.state.config.BANNERS = WEBUI_BANNERS
 app.state.config.MODEL_ORDER_LIST = MODEL_ORDER_LIST
@@ -1761,7 +1763,7 @@ async def get_app_config(request: Request):
                     else {}
                 ),
             }
-            if user is not None and (user.role in ["admin", "user"])
+            if user is not None and (user.role in ["admin", "user", "guest"])
             else {
                 **(
                     {

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -50,7 +50,10 @@ from open_webui.utils.auth import (
     get_http_authorization_cred,
 )
 from open_webui.utils.webhook import post_webhook
-from open_webui.utils.access_control import get_permissions
+from open_webui.utils.access_control import (
+    get_permissions,
+    get_role_permissions_config,
+)
 
 from typing import Optional, List
 
@@ -115,9 +118,10 @@ async def get_session_user(
             secure=WEBUI_AUTH_COOKIE_SECURE,
         )
 
-    user_permissions = get_permissions(
-        user.id, request.app.state.config.USER_PERMISSIONS
+    default_permissions, _ = get_role_permissions_config(
+        request.app.state.config, user.role
     )
+    user_permissions = get_permissions(user.id, default_permissions)
 
     return {
         "token": token,
@@ -416,9 +420,10 @@ async def ldap_auth(request: Request, response: Response, form_data: LdapForm):
                     secure=WEBUI_AUTH_COOKIE_SECURE,
                 )
 
-                user_permissions = get_permissions(
-                    user.id, request.app.state.config.USER_PERMISSIONS
+                default_permissions, _ = get_role_permissions_config(
+                    request.app.state.config, user.role
                 )
+                user_permissions = get_permissions(user.id, default_permissions)
 
                 if (
                     user.role != "admin"
@@ -538,9 +543,10 @@ async def signin(request: Request, response: Response, form_data: SigninForm):
             secure=WEBUI_AUTH_COOKIE_SECURE,
         )
 
-        user_permissions = get_permissions(
-            user.id, request.app.state.config.USER_PERMISSIONS
+        default_permissions, _ = get_role_permissions_config(
+            request.app.state.config, user.role
         )
+        user_permissions = get_permissions(user.id, default_permissions)
 
         return {
             "token": token,
@@ -647,9 +653,10 @@ async def signup(request: Request, response: Response, form_data: SignupForm):
                     },
                 )
 
-            user_permissions = get_permissions(
-                user.id, request.app.state.config.USER_PERMISSIONS
+            default_permissions, _ = get_role_permissions_config(
+                request.app.state.config, user.role
             )
+            user_permissions = get_permissions(user.id, default_permissions)
 
             if not has_users:
                 # Disable signup after the first user is created
@@ -880,7 +887,7 @@ async def update_admin_config(
     request.app.state.config.ENABLE_CHANNELS = form_data.ENABLE_CHANNELS
     request.app.state.config.ENABLE_NOTES = form_data.ENABLE_NOTES
 
-    if form_data.DEFAULT_USER_ROLE in ["pending", "user", "admin"]:
+    if form_data.DEFAULT_USER_ROLE in ["pending", "user", "guest", "admin"]:
         request.app.state.config.DEFAULT_USER_ROLE = form_data.DEFAULT_USER_ROLE
 
     pattern = r"^(-1|0|(-?\d+(\.\d+)?)(ms|s|m|h|d|w))$"

--- a/backend/open_webui/routers/folders.py
+++ b/backend/open_webui/routers/folders.py
@@ -29,7 +29,10 @@ from fastapi.responses import FileResponse, StreamingResponse
 
 
 from open_webui.utils.auth import get_admin_user, get_verified_user
-from open_webui.utils.access_control import has_permission
+from open_webui.utils.access_control import (
+    get_role_permissions_config,
+    has_permission,
+)
 
 
 log = logging.getLogger(__name__)
@@ -262,8 +265,15 @@ async def update_folder_is_expanded_by_id(
 async def delete_folder_by_id(
     request: Request, id: str, user=Depends(get_verified_user)
 ):
+    default_permissions, fallback_permissions = get_role_permissions_config(
+        request.app.state.config, user.role
+    )
+
     chat_delete_permission = has_permission(
-        user.id, "chat.delete", request.app.state.config.USER_PERMISSIONS
+        user.id,
+        "chat.delete",
+        default_permissions,
+        fallback_permissions,
     )
 
     if user.role != "admin" and not chat_delete_permission:

--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -18,7 +18,11 @@ from open_webui.env import SRC_LOG_LEVELS
 
 
 from open_webui.utils.auth import get_admin_user, get_verified_user
-from open_webui.utils.access_control import has_access, has_permission
+from open_webui.utils.access_control import (
+    get_role_permissions_config,
+    has_access,
+    has_permission,
+)
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MODELS"])
@@ -32,9 +36,15 @@ router = APIRouter()
 
 @router.get("/", response_model=list[NoteUserResponse])
 async def get_notes(request: Request, user=Depends(get_verified_user)):
+    default_permissions, fallback_permissions = get_role_permissions_config(
+        request.app.state.config, user.role
+    )
 
     if user.role != "admin" and not has_permission(
-        user.id, "features.notes", request.app.state.config.USER_PERMISSIONS
+        user.id,
+        "features.notes",
+        default_permissions,
+        fallback_permissions,
     ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -65,8 +75,15 @@ class NoteTitleIdResponse(BaseModel):
 async def get_note_list(
     request: Request, page: Optional[int] = None, user=Depends(get_verified_user)
 ):
+    default_permissions, fallback_permissions = get_role_permissions_config(
+        request.app.state.config, user.role
+    )
+
     if user.role != "admin" and not has_permission(
-        user.id, "features.notes", request.app.state.config.USER_PERMISSIONS
+        user.id,
+        "features.notes",
+        default_permissions,
+        fallback_permissions,
     ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -96,9 +113,15 @@ async def get_note_list(
 async def create_new_note(
     request: Request, form_data: NoteForm, user=Depends(get_verified_user)
 ):
+    default_permissions, fallback_permissions = get_role_permissions_config(
+        request.app.state.config, user.role
+    )
 
     if user.role != "admin" and not has_permission(
-        user.id, "features.notes", request.app.state.config.USER_PERMISSIONS
+        user.id,
+        "features.notes",
+        default_permissions,
+        fallback_permissions,
     ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -122,8 +145,15 @@ async def create_new_note(
 
 @router.get("/{id}", response_model=Optional[NoteModel])
 async def get_note_by_id(request: Request, id: str, user=Depends(get_verified_user)):
+    default_permissions, fallback_permissions = get_role_permissions_config(
+        request.app.state.config, user.role
+    )
+
     if user.role != "admin" and not has_permission(
-        user.id, "features.notes", request.app.state.config.USER_PERMISSIONS
+        user.id,
+        "features.notes",
+        default_permissions,
+        fallback_permissions,
     ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -156,8 +186,15 @@ async def get_note_by_id(request: Request, id: str, user=Depends(get_verified_us
 async def update_note_by_id(
     request: Request, id: str, form_data: NoteForm, user=Depends(get_verified_user)
 ):
+    default_permissions, fallback_permissions = get_role_permissions_config(
+        request.app.state.config, user.role
+    )
+
     if user.role != "admin" and not has_permission(
-        user.id, "features.notes", request.app.state.config.USER_PERMISSIONS
+        user.id,
+        "features.notes",
+        default_permissions,
+        fallback_permissions,
     ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -201,8 +238,15 @@ async def update_note_by_id(
 
 @router.delete("/{id}/delete", response_model=bool)
 async def delete_note_by_id(request: Request, id: str, user=Depends(get_verified_user)):
+    default_permissions, fallback_permissions = get_role_permissions_config(
+        request.app.state.config, user.role
+    )
+
     if user.role != "admin" and not has_permission(
-        user.id, "features.notes", request.app.state.config.USER_PERMISSIONS
+        user.id,
+        "features.notes",
+        default_permissions,
+        fallback_permissions,
     ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -506,7 +506,7 @@ async def get_ollama_tags(
                 detail=detail if detail else "Open WebUI: Server Connection Error",
             )
 
-    if user.role == "user" and not BYPASS_MODEL_ACCESS_CONTROL:
+    if user.role in {"user", "guest"} and not BYPASS_MODEL_ACCESS_CONTROL:
         models["models"] = await get_filtered_models(models, user)
 
     return models
@@ -1337,7 +1337,7 @@ async def generate_chat_completion(
             payload = apply_system_prompt_to_body(system, payload, metadata, user)
 
         # Check if user has access to the model
-        if not bypass_filter and user.role == "user":
+        if not bypass_filter and user.role in {"user", "guest"}:
             if not (
                 user.id == model_info.user_id
                 or has_access(
@@ -1443,7 +1443,7 @@ async def generate_openai_completion(
             payload = apply_model_params_to_body_openai(params, payload)
 
         # Check if user has access to the model
-        if user.role == "user":
+        if user.role in {"user", "guest"}:
             if not (
                 user.id == model_info.user_id
                 or has_access(
@@ -1526,7 +1526,7 @@ async def generate_openai_chat_completion(
             payload = apply_system_prompt_to_body(system, payload, metadata, user)
 
         # Check if user has access to the model
-        if user.role == "user":
+        if user.role in {"user", "guest"}:
             if not (
                 user.id == model_info.user_id
                 or has_access(
@@ -1621,7 +1621,7 @@ async def get_openai_models(
                 detail=error_detail,
             )
 
-    if user.role == "user" and not BYPASS_MODEL_ACCESS_CONTROL:
+    if user.role in {"user", "guest"} and not BYPASS_MODEL_ACCESS_CONTROL:
         # Filter models based on user access control
         filtered_models = []
         for model in models:

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -627,7 +627,7 @@ async def get_models(
                 error_detail = f"Unexpected error: {str(e)}"
                 raise HTTPException(status_code=500, detail=error_detail)
 
-    if user.role == "user" and not BYPASS_MODEL_ACCESS_CONTROL:
+    if user.role in {"user", "guest"} and not BYPASS_MODEL_ACCESS_CONTROL:
         models["data"] = await get_filtered_models(models, user)
 
     return models
@@ -831,7 +831,7 @@ async def generate_chat_completion(
             payload = apply_system_prompt_to_body(system, payload, metadata, user)
 
         # Check if user has access to the model
-        if not bypass_filter and user.role == "user":
+        if not bypass_filter and user.role in {"user", "guest"}:
             if not (
                 user.id == model_info.user_id
                 or has_access(

--- a/backend/open_webui/routers/prompts.py
+++ b/backend/open_webui/routers/prompts.py
@@ -9,7 +9,11 @@ from open_webui.models.prompts import (
 )
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.utils.auth import get_admin_user, get_verified_user
-from open_webui.utils.access_control import has_access, has_permission
+from open_webui.utils.access_control import (
+    get_role_permissions_config,
+    has_access,
+    has_permission,
+)
 from open_webui.config import BYPASS_ADMIN_ACCESS_CONTROL
 
 router = APIRouter()
@@ -48,8 +52,15 @@ async def get_prompt_list(user=Depends(get_verified_user)):
 async def create_new_prompt(
     request: Request, form_data: PromptForm, user=Depends(get_verified_user)
 ):
+    default_permissions, fallback_permissions = get_role_permissions_config(
+        request.app.state.config, user.role
+    )
+
     if user.role != "admin" and not has_permission(
-        user.id, "workspace.prompts", request.app.state.config.USER_PERMISSIONS
+        user.id,
+        "workspace.prompts",
+        default_permissions,
+        fallback_permissions,
     ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/open_webui/test/apps/webui/routers/test_auths.py
+++ b/backend/open_webui/test/apps/webui/routers/test_auths.py
@@ -111,7 +111,7 @@ class TestAuths(AbstractPostgresTest):
         assert data["id"] is not None and len(data["id"]) > 0
         assert data["name"] == "John Doe"
         assert data["email"] == "john.doe@openwebui.com"
-        assert data["role"] in ["admin", "user", "pending"]
+        assert data["role"] in ["admin", "user", "guest", "pending"]
         assert data["profile_image_url"] == "/user.png"
         assert data["token"] is not None and len(data["token"]) > 0
         assert data["token_type"] == "Bearer"

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -197,7 +197,7 @@ async def generate_chat_completion(
         )
     else:
         # Check if user has access to the model
-        if not bypass_filter and user.role == "user":
+        if not bypass_filter and user.role in {"user", "guest"}:
             try:
                 check_model_access(user, model)
             except Exception as e:

--- a/backend/open_webui/utils/embeddings.py
+++ b/backend/open_webui/utils/embeddings.py
@@ -69,7 +69,7 @@ async def generate_embeddings(
 
     # Access filtering
     if not getattr(request.state, "direct", False):
-        if not bypass_filter and user.role == "user":
+        if not bypass_filter and user.role in {"user", "guest"}:
             check_model_access(user, model)
 
     # Ollama backend

--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -338,7 +338,7 @@ def check_model_access(user, model):
 def get_filtered_models(models, user):
     # Filter out models that the user does not have access to
     if (
-        user.role == "user"
+        user.role in {"user", "guest"}
         or (user.role == "admin" and not BYPASS_ADMIN_ACCESS_CONTROL)
     ) and not BYPASS_MODEL_ACCESS_CONTROL:
         filtered_models = []

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -26,6 +26,7 @@ from open_webui.models.users import Users
 
 
 from open_webui.models.groups import Groups, GroupModel, GroupUpdateForm, GroupForm
+from open_webui.utils.access_control import get_role_permissions_config
 from open_webui.config import (
     DEFAULT_USER_ROLE,
     ENABLE_OAUTH_SIGNUP,
@@ -777,10 +778,13 @@ class OAuthManager:
                 auth_manager_config.ENABLE_OAUTH_GROUP_MANAGEMENT
                 and user.role != "admin"
             ):
+                default_permissions, _ = get_role_permissions_config(
+                    request.app.state.config, user.role
+                )
                 self.update_user_groups(
                     user=user,
                     user_data=user_data,
-                    default_permissions=request.app.state.config.USER_PERMISSIONS,
+                    default_permissions=default_permissions,
                 )
 
         except Exception as e:

--- a/src/lib/apis/users/index.ts
+++ b/src/lib/apis/users/index.ts
@@ -28,16 +28,25 @@ export const getUserGroups = async (token: string) => {
 	return res;
 };
 
-export const getUserDefaultPermissions = async (token: string) => {
-	let error = null;
+export const getUserDefaultPermissions = async (token: string, role: string = 'user') => {
+        let error = null;
 
-	const res = await fetch(`${WEBUI_API_BASE_URL}/users/default/permissions`, {
-		method: 'GET',
-		headers: {
-			'Content-Type': 'application/json',
-			Authorization: `Bearer ${token}`
-		}
-	})
+        const searchParams = new URLSearchParams();
+        if (role) {
+                searchParams.set('role', role);
+        }
+
+        const queryString = searchParams.toString();
+        const res = await fetch(
+                `${WEBUI_API_BASE_URL}/users/default/permissions${queryString ? `?${queryString}` : ''}`,
+                {
+                        method: 'GET',
+                        headers: {
+                                'Content-Type': 'application/json',
+                                Authorization: `Bearer ${token}`
+                        }
+                }
+        )
 		.then(async (res) => {
 			if (!res.ok) throw await res.json();
 			return res.json();
@@ -55,19 +64,32 @@ export const getUserDefaultPermissions = async (token: string) => {
 	return res;
 };
 
-export const updateUserDefaultPermissions = async (token: string, permissions: object) => {
-	let error = null;
+export const updateUserDefaultPermissions = async (
+        token: string,
+        permissions: object,
+        role: string = 'user'
+) => {
+        let error = null;
 
-	const res = await fetch(`${WEBUI_API_BASE_URL}/users/default/permissions`, {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json',
-			Authorization: `Bearer ${token}`
-		},
-		body: JSON.stringify({
-			...permissions
-		})
-	})
+        const searchParams = new URLSearchParams();
+        if (role) {
+                searchParams.set('role', role);
+        }
+
+        const queryString = searchParams.toString();
+        const res = await fetch(
+                `${WEBUI_API_BASE_URL}/users/default/permissions${queryString ? `?${queryString}` : ''}`,
+                {
+                        method: 'POST',
+                        headers: {
+                                'Content-Type': 'application/json',
+                                Authorization: `Bearer ${token}`
+                        },
+                        body: JSON.stringify({
+                                ...permissions
+                        })
+                }
+        )
 		.then(async (res) => {
 			if (!res.ok) throw await res.json();
 			return res.json();

--- a/src/lib/components/admin/Users/UserList/AddUserModal.svelte
+++ b/src/lib/components/admin/Users/UserList/AddUserModal.svelte
@@ -81,7 +81,7 @@
 						if (idx > 0) {
 							if (
 								columns.length === 4 &&
-								['admin', 'user', 'pending'].includes(columns[3].toLowerCase())
+                                                            ['admin', 'user', 'guest', 'pending'].includes(columns[3].toLowerCase())
 							) {
 								const res = await addUser(
 									localStorage.token,
@@ -186,7 +186,8 @@
 										required
 									>
 										<option value="pending"> {$i18n.t('pending')} </option>
-										<option value="user"> {$i18n.t('user')} </option>
+                                                                                <option value="user"> {$i18n.t('user')} </option>
+                                                                                <option value="guest"> {$i18n.t('guest')} </option>
 										<option value="admin"> {$i18n.t('admin')} </option>
 									</select>
 								</div>

--- a/src/lib/components/admin/Users/UserList/EditUserModal.svelte
+++ b/src/lib/components/admin/Users/UserList/EditUserModal.svelte
@@ -114,9 +114,10 @@
 										disabled={_user.id == sessionUser.id}
 										required
 									>
-										<option value="admin">{$i18n.t('Admin')}</option>
-										<option value="user">{$i18n.t('User')}</option>
-										<option value="pending">{$i18n.t('Pending')}</option>
+                                                                                <option value="admin">{$i18n.t('Admin')}</option>
+                                                                                <option value="user">{$i18n.t('User')}</option>
+                                                                                <option value="guest">{$i18n.t('Guest')}</option>
+                                                                                <option value="pending">{$i18n.t('Pending')}</option>
 									</select>
 								</div>
 							</div>


### PR DESCRIPTION
## Summary
- introduce guest role configuration with dedicated default permissions
- update permission checks to respect role-specific defaults and treat guests like users for access control
- extend admin UI to manage guest defaults and expose the guest role in user management

## Testing
- npm run lint *(fails: ESLint config missing; svelte-kit and pylint commands unavailable in container)*
- pytest backend/open_webui/test/apps/webui/routers/test_auths.py *(fails: ModuleNotFoundError: No module named 'test.util')*

------
https://chatgpt.com/codex/tasks/task_e_68d14d95bc4c83328d90039dcef1c64f