### PR TITLE
feat: support automatic guest sessions

### DIFF
--- a/src/lib/apis/auths/index.ts
+++ b/src/lib/apis/auths/index.ts
@@ -1,5 +1,48 @@
 import { WEBUI_API_BASE_URL } from '$lib/constants';
 
+export type SessionUserResponse = {
+        token: string;
+        token_type: string;
+        expires_at: number | null;
+        id: string;
+        email: string;
+        name: string;
+        role: string;
+        profile_image_url: string;
+        permissions: any;
+};
+
+export const guestSignIn = async (): Promise<SessionUserResponse> => {
+        let error: any = null;
+
+        const res = await fetch(`${WEBUI_API_BASE_URL}/auths/guest`, {
+                method: 'POST',
+                headers: {
+                        'Content-Type': 'application/json'
+                },
+                credentials: 'include'
+        })
+                .then(async (res) => {
+                        if (!res.ok) throw await res.json();
+                        return res.json();
+                })
+                .catch((err) => {
+                        console.error(err);
+                        error = err?.detail ?? err;
+                        return null;
+                });
+
+        if (error) {
+                throw error;
+        }
+
+        if (res?.token) {
+                localStorage.token = res.token;
+        }
+
+        return res;
+};
+
 export const getAdminDetails = async (token: string) => {
 	let error = null;
 

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -251,10 +251,11 @@ type Config = {
 		enable_signup: boolean;
 		enable_login_form: boolean;
 		enable_web_search?: boolean;
-		enable_google_drive_integration: boolean;
-		enable_onedrive_integration: boolean;
-		enable_image_generation: boolean;
-		enable_admin_export: boolean;
+                enable_google_drive_integration: boolean;
+                enable_onedrive_integration: boolean;
+                enable_image_generation: boolean;
+                enable_guest_mode: boolean;
+                enable_admin_export: boolean;
 		enable_admin_chat_access: boolean;
 		enable_community_sharing: boolean;
 		enable_autocomplete_generation: boolean;

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -153,11 +153,16 @@
 		}
 	}
 
-	onMount(async () => {
-		const redirectPath = $page.url.searchParams.get('redirect');
-		if ($user !== undefined) {
-			goto(redirectPath || '/');
-		} else {
+        onMount(async () => {
+                if ($config?.features.enable_guest_mode && !localStorage.token) {
+                        goto('/');
+                        return;
+                }
+
+                const redirectPath = $page.url.searchParams.get('redirect');
+                if ($user !== undefined) {
+                        goto(redirectPath || '/');
+                } else {
 			if (redirectPath) {
 				localStorage.setItem('redirectPath', redirectPath);
 			}


### PR DESCRIPTION
## Summary
- add a typed `guestSignIn` helper that posts to `/auths/guest` and syncs the session token
- invoke guest sign-in during layout initialization when guest mode is enabled and no token is present
- guard the auth page and config typings so guest sessions bypass the manual login form

## Testing
- npm run lint *(fails: existing ESLint/Svelte/type issues and missing `pylint` in the current environment)*
- npm run test:frontend


------
https://chatgpt.com/codex/tasks/task_e_68d180e0d630833286bd9ff524515c12